### PR TITLE
add: 공휴일 단어시험지 노출x

### DIFF
--- a/built/index.js
+++ b/built/index.js
@@ -1,5 +1,40 @@
 import { vocabularies, vocabulariesTestRange } from "./data.js";
+const holidays = [
+    "2023/01/01",
+    "2023/01/23",
+    "2023/01/24",
+    "2023/02/03",
+    "2023/03/01",
+    "2023/05/05",
+    "2023/05/29",
+    "2023/06/05",
+    "2023/08/15",
+    "2023/09/28",
+    "2023/09/29",
+    "2023/10/03",
+    "2023/10/09",
+    "2023/12/25", // 크리스마스
+];
+const convertDateFormat = (date) => {
+    return date.toLocaleDateString(); // 6/5/2023
+};
+const getTimeStamp = (day) => {
+    return new Date(day).getTime();
+};
+const isTodayHoliday = () => {
+    const today = convertDateFormat(new Date());
+    const holiday = holidays.filter(holiday => getTimeStamp(holiday) === getTimeStamp(today));
+    return holiday.length !== 0;
+};
 const init = () => {
+    const holidayYn = isTodayHoliday();
+    if (holidayYn) {
+        const { $testWrapper } = getHTMLElement();
+        if (!$testWrapper)
+            return;
+        $testWrapper.innerHTML = '<div class="full"><p>🎉 오늘은 쉬는 날 🎉</p><p>(문제섞기X,인쇄X)</p></div>';
+        return;
+    }
     updateVocabularyRange();
     updateVocabulary();
     handleSort();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,48 @@
 import { vocabularies, vocabulariesTestRange } from "./data.js";
 import { VocabularyType } from "./type";
 
+const holidays = [
+  "2023/01/01",// 신정
+  "2023/01/23",// 설날
+  "2023/01/24",// 설날
+  "2023/02/03", // 창립기념일
+  "2023/03/01", // 삼일절
+  "2023/05/05", // 어린이날
+  "2023/05/29",// 석가탄신일
+  "2023/06/05", // 현충일
+  "2023/08/15",// 광복절
+  "2023/09/28",// 추석
+  "2023/09/29",// 추석(연휴)
+  "2023/10/03",// 개천절
+  "2023/10/09",// 한글날
+  "2023/12/25",// 크리스마스
+] as const;
+
+const convertDateFormat = (date: Date) => {
+  return date.toLocaleDateString(); // 6/5/2023
+}
+
+const getTimeStamp = (day: string) => {
+  return new Date(day).getTime();
+}
+
+const isTodayHoliday = () => {
+  const today = convertDateFormat(new Date());
+  const holiday = holidays.filter(holiday => getTimeStamp(holiday) === getTimeStamp(today));
+
+  return holiday.length !== 0;
+};
+
 const init = () => {
+  const holidayYn = isTodayHoliday();
+  if (holidayYn) {
+    const { $testWrapper } = getHTMLElement();
+    if (!$testWrapper) return;
+
+    $testWrapper.innerHTML = '<div class="full"><p>🎉 오늘은 쉬는 날 🎉</p><p>(문제섞기X,인쇄X)</p></div>';
+    return;
+  }
+
   updateVocabularyRange();
   updateVocabulary();
   handleSort();

--- a/src/style.css
+++ b/src/style.css
@@ -63,6 +63,19 @@
     margin-inline: auto;
     width: 1000px;
   }
+  .full {
+    height: calc(100vh - 100px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-2);
+    font-size: var(--font-large);
+  }
+  .full p:last-child {
+    font-size: var(--font-normal);
+  }
+
   .test-title {
     width: var(--full-width);
   }


### PR DESCRIPTION
## feature
as-is
데이터에 맞추어 단어시험지 항상 노출

to-be
공휴일엔 단어시험지 노출x

## related
- #8 

> 👇🏻 as-is
![asis html](https://github.com/sukyoungshin/vocabulary-test/assets/87718391/36ded14c-6707-4b08-a09c-9f8252e74006)

> 👇🏻 to-be
![tobe html](https://github.com/sukyoungshin/vocabulary-test/assets/87718391/19b44cac-8d89-4110-a444-8635eeb0b1cc)
